### PR TITLE
Update flask.mdx

### DIFF
--- a/site/src/docs/starters/flask.mdx
+++ b/site/src/docs/starters/flask.mdx
@@ -75,5 +75,7 @@ $ heroku login -i
 $ heroku create <your_application_name>
 // Commit and push to heroku (commited your changes)
 $ git push heroku main
+// Change the heroku stack version to heroku-20 to make it work with this boilerplate (if you haven't already done so)
+$ heroku stack:set heroku-20
 ```
 :warning: For a more detailed explanation on working with .env variables or the MySQL database [read the full guide](https://github.com/4GeeksAcademy/flask-rest-hello/blob/master/docs/DEPLOY_YOUR_APP.md).


### PR DESCRIPTION
Heroku-22 stack is used my default when the heroku cli is installed. Heroku-22 stack does NOT support python 3.7.15 which is the version being used by the boilerplate to set up the virtual environment. Setting the version to heroku-20 is necessary for everything to work properly.

More information here: https://devcenter.heroku.com/articles/python-support#supported-runtimes